### PR TITLE
Pass a Fraction type value to PyAV's `container.add_stream(rate=)`

### DIFF
--- a/app/utils_videos.py
+++ b/app/utils_videos.py
@@ -4,6 +4,7 @@
 import av
 import torch
 import numpy as np
+from fractions import Fraction
 
 def write_video(video_frames, output_path, fps, audio_samples=None, sample_rate=None, acodec="aac"):
     assert video_frames.ndim == 4, "Input frames should be a 4D array."
@@ -14,7 +15,7 @@ def write_video(video_frames, output_path, fps, audio_samples=None, sample_rate=
         video_frames = video_frames.astype(np.uint8)
     _, _, height, width = video_frames.shape
     container = av.open(output_path, mode="w")
-    stream = container.add_stream("h264", rate=fps)
+    stream = container.add_stream("h264", rate=Fraction(fps).limit_denominator(1000))
     stream.width = width
     stream.height = height
     stream.pix_fmt = "yuv420p"


### PR DESCRIPTION
because a newer version started to require the argument to be of type int or Fraction.

With the latest version of PyAV, the current code using a float value causes the following error:
```
  File "/workspace/ARTalk/inference.py", line 122, in process_audio
    engine.rendering(audio, pred_motions, shape_id=shape_id, save_name=save_name)
  File "/workspace/ARTalk/inference.py", line 86, in rendering
    write_video(pred_images*255.0, dump_path, 25.0, audio, 16000, "aac")
  File "/workspace/ARTalk/app/utils_videos.py", line 17, in write_video
    stream = container.add_stream("h264", rate=fps)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "av/container/output.py", line 86, in av.container.output.OutputContainer.add_stream
  File "av/utils.py", line 70, in av.utils.to_avrational
AttributeError: 'float' object has no attribute 'numerator'
```