### PR TITLE
Allow passing an explicit FLAME model path to FLAMEModel

### DIFF
--- a/app/flame_model/FLAME.py
+++ b/app/flame_model/FLAME.py
@@ -18,15 +18,15 @@ class FLAMEModel(nn.Module):
     Given flame parameters this class generates a differentiable FLAME function
     which outputs the a mesh and 2D/3D facial landmarks
     """
-    def __init__(self, n_shape, n_exp, scale=1.0, no_lmks=False, lmks_type='lmks70'):
+    def __init__(self, n_shape, n_exp, scale=1.0, no_lmks=False, lmks_type='lmks70', model_path=None):
         super().__init__()
         self.scale = scale
         self.no_lmks, self.lmks_type = no_lmks, lmks_type
         # print("creating the FLAME Model")
         _abs_path = os.path.dirname(os.path.abspath(__file__))
-        self.flame_ckpt = torch.load(
-            os.path.join(_abs_path, '../../assets', 'FLAME_with_eye.pt'), map_location='cpu', weights_only=True
-        )
+        if model_path is None:
+            model_path = os.path.join(_abs_path, '../../assets', 'FLAME_with_eye.pt')
+        self.flame_ckpt = torch.load(model_path, map_location='cpu', weights_only=True)
         flame_model = self.flame_ckpt['flame_model']
         flame_lmk = self.flame_ckpt['lmk_embeddings']
         flame_dense_lmk = self.flame_ckpt['lmk_embeddings_mediapipe']


### PR DESCRIPTION
Part 1 of the upstreaming sequence proposed in #30.

`FLAMEModel` resolved `FLAME_with_eye.pt` only relative to the source tree, which breaks when the code is used as an installed library or when assets live elsewhere. This keeps the exact same default behavior and adds an optional `model_path` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)