### PR TITLE
Add a verified asset manifest and downloader CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+!artalk/assets_manifest.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Prepare resources with:
 bash ./build_resources.sh
 ```
 
+When ARTalk is installed as a package, the asset manifest can be used instead:
+```
+artalk-assets download --root assets --include-optional
+```
+
+This downloads only assets with explicit upstream sources and verifies known
+sizes and SHA-256 hashes. `FLAME_with_eye.pt` is listed in the manifest but is
+not downloaded automatically because FLAME has separate access and license
+terms; provide it manually at `assets/FLAME_with_eye.pt`.
+
 ## Quick Start Guide
 ### Using <a href="https://github.com/gradio-app/gradio">Gradio</a> Interface
 

--- a/artalk/__init__.py
+++ b/artalk/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
 # Copyright (c) Xuangeng Chu (xg.chu@outlook.com)
 
+from .assets import ARTalkAssets
 from .models import BitwiseARModel

--- a/artalk/assets.py
+++ b/artalk/assets.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+
+"""Asset resolution helpers for ARTalk runtime integrations."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import urllib.request
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
+
+
+class AssetConfigError(RuntimeError):
+    """Raised when ARTalk assets cannot be resolved or validated."""
+
+
+class AssetDownloadError(RuntimeError):
+    """Raised when an ARTalk asset cannot be downloaded or verified."""
+
+
+@dataclass(frozen=True)
+class ARTalkAssets:
+    root: Path
+
+    @classmethod
+    def from_root(cls, root: str | Path) -> "ARTalkAssets":
+        return cls(Path(root).expanduser().resolve())
+
+    @classmethod
+    def from_pyproject(cls, project_root: str | Path | None = None) -> "ARTalkAssets":
+        pyproject = find_pyproject(Path(project_root) if project_root else Path.cwd())
+        data = load_pyproject(pyproject)
+        assets = data.get("tool", {}).get("artalk", {}).get("assets", {})
+        root = assets.get("root")
+        if not root:
+            raise AssetConfigError(f"Missing [tool.artalk.assets].root in {pyproject}")
+        return cls.from_root(resolve_config_path(root, pyproject.parent))
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        root: str | Path | None = None,
+        project_root: str | Path | None = None,
+        env_var: str = "ARTALK_ASSET_DIR",
+        fallback_root: str | Path = "assets",
+    ) -> "ARTalkAssets":
+        if root is not None:
+            return cls.from_root(root)
+        if os.environ.get(env_var):
+            return cls.from_root(os.environ[env_var])
+        try:
+            return cls.from_pyproject(project_root)
+        except AssetConfigError:
+            return cls.from_root(fallback_root)
+
+    def checkpoint(self, audio_encoder: str = "wav2vec") -> Path:
+        return self.root / f"ARTalk_{audio_encoder}.pt"
+
+    @property
+    def config(self) -> Path:
+        return self.root / "config.json"
+
+    @property
+    def flame_model(self) -> Path:
+        return self.root / "FLAME_with_eye.pt"
+
+    @property
+    def style_motion_dir(self) -> Path:
+        return self.root / "style_motion"
+
+    @property
+    def gagavatar_dir(self) -> Path:
+        return self.root / "GAGAvatar"
+
+    def validate(self, audio_encoder: str = "wav2vec") -> None:
+        required = [
+            self.root,
+            self.checkpoint(audio_encoder),
+            self.config,
+            self.flame_model,
+        ]
+        missing = [path for path in required if not path.exists()]
+        if missing:
+            details = "\n".join(f"- {path}" for path in missing)
+            raise AssetConfigError(f"Missing ARTalk asset files:\n{details}")
+
+
+def find_pyproject(start: Path) -> Path:
+    current = start.expanduser().resolve()
+    if current.is_file():
+        current = current.parent
+    for directory in [current, *current.parents]:
+        pyproject = directory / "pyproject.toml"
+        if pyproject.exists():
+            return pyproject
+    raise AssetConfigError(f"No pyproject.toml found from {start}")
+
+
+def load_pyproject(path: Path) -> dict[str, Any]:
+    if tomllib is None:
+        raise AssetConfigError(
+            f"Reading {path} requires Python >= 3.11 or the tomli package."
+        )
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def resolve_config_path(value: str | Path, base_dir: Path) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base_dir / path
+    return path.resolve()
+
+
+def load_asset_manifest() -> dict[str, Any]:
+    return json.loads(files(__package__).joinpath("assets_manifest.json").read_text())
+
+
+def iter_manifest_assets(*, include_optional: bool = False) -> list[dict[str, Any]]:
+    assets = load_asset_manifest()["assets"]
+    if include_optional:
+        return assets
+    return [asset for asset in assets if asset.get("required", True)]
+
+
+def download_assets(
+    root: str | Path,
+    *,
+    names: set[str] | None = None,
+    include_optional: bool = False,
+    force: bool = False,
+    dry_run: bool = False,
+    verify: bool = True,
+) -> None:
+    root_path = Path(root).expanduser().resolve()
+    candidates = iter_manifest_assets(include_optional=True if names else include_optional)
+    selected = [asset for asset in candidates if names is None or asset["name"] in names]
+    if names:
+        known = {asset["name"] for asset in iter_manifest_assets(include_optional=True)}
+        unknown = names - known
+        if unknown:
+            raise AssetDownloadError(f"Unknown ARTalk asset names: {', '.join(sorted(unknown))}")
+
+    manual_assets = []
+    for asset in selected:
+        destination = root_path / asset["path"]
+        if asset.get("manual"):
+            manual_assets.append(asset)
+            print(f"manual: {asset['name']} -> {destination}")
+            continue
+        url = asset_download_url(asset)
+        if dry_run:
+            print(f"download: {url} -> {destination}")
+            continue
+        if destination.exists() and not force:
+            if verify and asset.get("sha256"):
+                verify_asset(destination, asset)
+            print(f"exists: {destination}")
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_suffix(destination.suffix + ".part")
+        print(f"download: {url} -> {destination}")
+        download_file(url, temporary)
+        if verify and asset.get("sha256"):
+            verify_asset(temporary, asset)
+        temporary.replace(destination)
+
+    if manual_assets:
+        print("\nManual assets were not downloaded:")
+        for asset in manual_assets:
+            print(f"- {asset['path']}: {asset.get('note', 'manual download required')}")
+
+
+def asset_download_url(asset: dict[str, Any]) -> str:
+    source = asset.get("source") or {}
+    if source.get("type") != "huggingface":
+        raise AssetDownloadError(f"Unsupported source for {asset['name']}: {source}")
+    repo_id = source["repo_id"]
+    revision = source.get("revision", "main")
+    filename = source["filename"]
+    return f"https://huggingface.co/{repo_id}/resolve/{revision}/{filename}?download=true"
+
+
+def download_file(url: str, destination: Path, timeout_s: float = 60.0) -> None:
+    with urllib.request.urlopen(url, timeout=timeout_s) as response:
+        with destination.open("wb") as output:
+            shutil.copyfileobj(response, output, length=1024 * 1024)
+
+
+def verify_asset(path: Path, asset: dict[str, Any]) -> None:
+    expected_size = asset.get("size")
+    if expected_size is not None and path.stat().st_size != expected_size:
+        raise AssetDownloadError(
+            f"Invalid size for {path}: {path.stat().st_size}, expected {expected_size}"
+        )
+    expected_sha256 = asset.get("sha256")
+    if expected_sha256 and sha256_file(path) != expected_sha256:
+        raise AssetDownloadError(f"Invalid SHA-256 for {path}")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="artalk-assets")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subcommands.add_parser("list", help="List ARTalk asset manifest entries.")
+    list_parser.add_argument("--include-optional", action="store_true")
+
+    download_parser = subcommands.add_parser("download", help="Download ARTalk assets.")
+    download_parser.add_argument("--root", default="assets")
+    download_parser.add_argument("--asset", action="append", dest="assets")
+    download_parser.add_argument("--include-optional", action="store_true")
+    download_parser.add_argument("--force", action="store_true")
+    download_parser.add_argument("--dry-run", action="store_true")
+    download_parser.add_argument("--no-verify", action="store_true")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "list":
+            for asset in iter_manifest_assets(include_optional=args.include_optional):
+                marker = "manual" if asset.get("manual") else "download"
+                required = "required" if asset.get("required", True) else "optional"
+                print(f"{asset['name']}: {asset['path']} ({marker}, {required})")
+            return 0
+        if args.command == "download":
+            download_assets(
+                args.root,
+                names=set(args.assets) if args.assets else None,
+                include_optional=args.include_optional,
+                force=args.force,
+                dry_run=args.dry_run,
+                verify=not args.no_verify,
+            )
+            return 0
+    except AssetDownloadError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artalk/assets_manifest.json
+++ b/artalk/assets_manifest.json
@@ -1,0 +1,265 @@
+{
+  "version": 1,
+  "assets": [
+    {
+      "name": "artalk_wav2vec",
+      "path": "ARTalk_wav2vec.pt",
+      "required": true,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "ARTalk_wav2vec.pt"
+      },
+      "size": 1959150898,
+      "sha256": "d89615a32e2a6b4e35cf5494c1e400b2acedc43812f63423b9f5d705046d67c2",
+      "license_note": "See upstream xg-chu/ARTalk model card."
+    },
+    {
+      "name": "config",
+      "path": "config.json",
+      "required": true,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "config.json"
+      },
+      "size": 303,
+      "sha256": "7546248a7eace5184a3b072de6fac80f22109e32f073ba4f616a7971a6f190fe",
+      "license_note": "See upstream xg-chu/ARTalk model card."
+    },
+    {
+      "name": "flame_with_eye",
+      "path": "FLAME_with_eye.pt",
+      "required": true,
+      "manual": true,
+      "size": 26819643,
+      "sha256": "b87a1d3513b3df0504f1e1f93bcb85ac01abe4dadf92e75ac08046c4a68403be",
+      "note": "FLAME assets have separate access and licensing terms. Download or provide this file manually."
+    },
+    {
+      "name": "gagavatar_model",
+      "path": "GAGAvatar/GAGAvatar.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/GAGAvatar",
+        "revision": "main",
+        "filename": "assets/GAGAvatar.pt"
+      },
+      "size": 747434426,
+      "sha256": "75d449fd1d67dd7bbc613cef17f0196b1c84766935adc75d5231bc89e33950f8",
+      "license_note": "See upstream xg-chu/GAGAvatar model card."
+    },
+    {
+      "name": "tracked_avatars",
+      "path": "GAGAvatar/tracked.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "GAGAvatar/tracked.pt"
+      },
+      "size": 183503648,
+      "sha256": "9b716493929ca0a19a50ce87c291627ff15d81980cad572f75b8d023dc3770fd",
+      "license_note": "Example tracked avatars from upstream ARTalk. Do not replace this with private tracked avatars for redistribution."
+    },
+    {
+      "name": "style_angry_0",
+      "path": "style_motion/angry_0.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/angry_0.pt"
+      },
+      "size": 2365843,
+      "sha256": "4f17f930661c1e42306ecf6e222b370ca2c4f775dbc63bde6402ca2f8135c556"
+    },
+    {
+      "name": "style_curious_0",
+      "path": "style_motion/curious_0.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/curious_0.pt"
+      },
+      "size": 680437,
+      "sha256": "f0db8a645684583af9694d72924cad9b4ac4d16d1a3e7c26c979fa9a7a51220d"
+    },
+    {
+      "name": "style_doubtful_0",
+      "path": "style_motion/doubtful_0.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/doubtful_0.pt"
+      },
+      "size": 2333193,
+      "sha256": "65863da3c4cc9fc11604f21c660684864ddfd135f88a84c0f25d0adba25bfc36"
+    },
+    {
+      "name": "style_doubtful_1",
+      "path": "style_motion/doubtful_1.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/doubtful_1.pt"
+      },
+      "size": 1062478,
+      "sha256": "2ea3241f8a9a3bd3f428ba77d76720c32ef8696042d05329af4f7e95a1baecce"
+    },
+    {
+      "name": "style_happy_0",
+      "path": "style_motion/happy_0.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/happy_0.pt"
+      },
+      "size": 2386200,
+      "sha256": "fdba588c443f1cfb17a11781b37515ababd933f65564a32f6859622ff62d3412"
+    },
+    {
+      "name": "style_happy_1",
+      "path": "style_motion/happy_1.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/happy_1.pt"
+      },
+      "size": 531573,
+      "sha256": "3ed4aa1ee540c136e88546a63ae324ac4f677a72a3bd41423fab1a5eea7c30ca"
+    },
+    {
+      "name": "style_happy_2",
+      "path": "style_motion/happy_2.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/happy_2.pt"
+      },
+      "size": 638005,
+      "sha256": "0b39a71e934c3bca01dce558e08b1953935392f98f1334e39759e0c9023cbd0f"
+    },
+    {
+      "name": "style_natural_0",
+      "path": "style_motion/natural_0.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_0.pt"
+      },
+      "size": 3129038,
+      "sha256": "5c929ca5a4f91ef8c4921964648cd2724f9e10d0ca520e0207009a2ed9b2bdcd"
+    },
+    {
+      "name": "style_natural_1",
+      "path": "style_motion/natural_1.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_1.pt"
+      },
+      "size": 696565,
+      "sha256": "775273821b842701d41acc17ed8bc022c806c9a44cc77b860213c6e56fe36612"
+    },
+    {
+      "name": "style_natural_2",
+      "path": "style_motion/natural_2.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_2.pt"
+      },
+      "size": 1327054,
+      "sha256": "7cebd082ba8fa4bb91c1d51c6a7a7c9e26c8892f648c9942f49344d42264de70"
+    },
+    {
+      "name": "style_natural_3",
+      "path": "style_motion/natural_3.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_3.pt"
+      },
+      "size": 1433043,
+      "sha256": "ae85ce6fbeaa3af633ee1022a6f96a543a88f40becd61a4c5f0bc997ab074078"
+    },
+    {
+      "name": "style_natural_4",
+      "path": "style_motion/natural_4.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_4.pt"
+      },
+      "size": 2811460,
+      "sha256": "cc76e17d724001d3d047c6d40c9c86a50550e7fb734a11bf043cc1eaad376005"
+    },
+    {
+      "name": "style_natural_5",
+      "path": "style_motion/natural_5.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_5.pt"
+      },
+      "size": 391285,
+      "sha256": "838dc72fccb22908dfc61b8965225295a7ae0c84a57f0672da31a48327b09fc0"
+    },
+    {
+      "name": "style_natural_6",
+      "path": "style_motion/natural_6.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_6.pt"
+      },
+      "size": 716469,
+      "sha256": "b32a9d6ed07978d375e51f0f8da9ece1b3e4bc8dad64a281f990fe712c54d7eb"
+    },
+    {
+      "name": "style_natural_7",
+      "path": "style_motion/natural_7.pt",
+      "required": false,
+      "source": {
+        "type": "huggingface",
+        "repo_id": "xg-chu/ARTalk",
+        "revision": "main",
+        "filename": "style_motion/natural_7.pt"
+      },
+      "size": 620213,
+      "sha256": "7ee71908c968e3a02f7d00c4079cbae0227551251da7a08ad2ed6ee074cd42f6"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,11 @@ description = "ARTalk: speech-driven 3D head animation"
 readme = "README.md"
 requires-python = ">=3.10"
 
+[project.scripts]
+artalk-assets = "artalk.assets:main"
+
 [tool.setuptools.packages.find]
 include = ["artalk*"]
+
+[tool.setuptools.package-data]
+artalk = ["assets_manifest.json"]


### PR DESCRIPTION
Part 3 of the upstreaming sequence in #30.

## Why a new downloader

The sequence in #30 makes ARTalk consumable as a pip-installed library, and at that point `build_resources.sh` cannot do the job: it lives in the repository checkout, which a `pip install artalk` user does not have. `artalk-assets` travels with the package (a console script plus a bundled manifest), so any environment that can `import artalk` can also fetch the assets it needs, into whatever `--root` the application chose.

Beyond reachability, it addresses real weaknesses of blind `wget`:

- **Integrity** — every asset is pinned by size + SHA-256 (and HF revision). A truncated or changed download fails loudly at fetch time, instead of surfacing later as a confusing checkpoint-loading error.
- **Idempotence and scriptability** — re-running verifies existing files rather than re-downloading ~2 GB; `--asset`, `--dry-run`, and `--force` make it selective; no bash/wget dependency, so it also works on Windows.
- **A programmatic surface** — `ARTalkAssets` gives library consumers a validated, path-typed view of an asset tree (checkpoint / config / FLAME / styles), which the runtime API in the next PR builds on; a shell script cannot be imported.
- **License-awareness as data** — the manifest represents `FLAME_with_eye.pt` but marks it manual-only, so "downloadable" vs. "obtain under FLAME's terms" is machine-readable rather than an interactive prompt.

## What's added

- `artalk/assets_manifest.json` — upstream URL, size, and SHA-256 per asset;
- the `artalk-assets` console script (`list` / `download`);
- `ARTalkAssets`, the validated path-typed view for library consumers.

## Relationship to build_resources.sh

Deliberately **not** a replacement: the script is untouched and keeps its interactive FLAME consent flow for repo-checkout users. The manifest covers everything the script fetches, with the one deliberate exception that the downloader never fetches FLAME. If you later consider the manifest canonical, the script can become a thin wrapper over `artalk-assets` (or be retired) — happy to send that follow-up, but that's your call.

## Verified

`artalk-assets list` shows the manifest; `ARTalkAssets.from_root(...)` validates an existing full asset tree; a real `download --asset config` fetched from the HF repo and passed size/hash verification; a full `--include-optional --dry-run` enumerates the same set of files the shell script downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)