### PR TITLE
Require Python 3.11 and drop the tomllib fallback

### DIFF
--- a/artalk/assets.py
+++ b/artalk/assets.py
@@ -16,13 +16,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
-    try:
-        import tomli as tomllib
-    except ModuleNotFoundError:
-        tomllib = None
+import tomllib
 
 
 class AssetConfigError(RuntimeError):
@@ -113,10 +107,6 @@ def find_pyproject(start: Path) -> Path:
 
 
 def load_pyproject(path: Path) -> dict[str, Any]:
-    if tomllib is None:
-        raise AssetConfigError(
-            f"Reading {path} requires Python >= 3.11 or the tomli package."
-        )
     with path.open("rb") as f:
         return tomllib.load(f)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "artalk"
 version = "0.1.0"
 description = "ARTalk: speech-driven 3D head animation"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.scripts]
 artalk-assets = "artalk.assets:main"


### PR DESCRIPTION
Small follow-up to #33, mirroring the same change already applied to the GAGAvatar twin (xg-chu/GAGAvatar#67 was updated in place).

Python 3.10 reaches end of life in October 2026, and this project's own `environment.yml` already pins Python 3.12 — so `requires-python = ">=3.10"` only forced `assets.py` to carry a `tomli` import fallback for reading pyproject files. This requires 3.11 (where `tomllib` is in the standard library) and deletes the fallback: net −10 lines.

Verified: `artalk-assets list`, asset-tree validation, and pyproject reading all pass on the simplified module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)