### PR TITLE
Add streaming inference and a causal motion smoother

### DIFF
--- a/artalk/streaming.py
+++ b/artalk/streaming.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python
+# Copyright (c) Xuangeng Chu (xg.chu@outlook.com)
+
+"""Streaming pieces for ARTalk inference.
+
+This module hosts two streaming-friendly counterparts to the one-shot
+inference pipeline; see ``docs/realtime.md`` for the design rationale.
+
+* :class:`ARTalkStreamer` — streaming wrapper around
+  ``BitwiseARModel.inference``. The released model processes audio in
+  fixed 4-second / 100-frame chunks, and chunk-to-chunk state (previous
+  code bits and the rolling attention-feature buffer) is the only thing
+  that crosses chunk boundaries; this class exposes that chunked
+  computation as a stateful ``feed`` / ``finish`` API. Output is
+  bit-exact with one-shot ``BitwiseARModel.inference``.
+
+* :class:`CausalSavgolSmoother` — streaming counterpart to
+  ``ARTAvatarInferEngine.smooth_motion_savgol``. Adds a 4-frame
+  (160 ms at 25 fps) emission delay in exchange for output that is
+  bit-exact with the one-shot smoother.
+
+``scripts/check_streaming_parity.py`` asserts both parity properties.
+
+Other engine post-processing (eye-channel zeroing, ``fix_pose``,
+``clip_length`` truncation) is not streaming-aware and stays at the
+engine layer.
+"""
+
+import math
+
+import torch
+import torch.nn.functional as F
+from scipy.signal import savgol_filter
+
+
+SAMPLE_RATE = 16000
+FPS = 25.0
+
+
+class ARTalkStreamer:
+    def __init__(self, model, style_motion=None):
+        self.model = model
+        self.patch_audio_length = int(model.patch_nums[-1] / FPS * SAMPLE_RATE)
+        self.frames_per_chunk = model.patch_nums[-1]
+        self.motion_dim = model.basic_vae.motion_dim
+        self.set_style(style_motion)
+        self.reset()
+
+    @property
+    def device(self):
+        return self.model.device
+
+    @property
+    def dtype(self):
+        return next(self.model.parameters()).dtype
+
+    @torch.no_grad()
+    def set_style(self, style_motion=None):
+        model = self.model
+        if style_motion is not None:
+            if style_motion.dim() == 2:
+                style_motion = style_motion[None]
+            style_motion = style_motion.to(device=self.device, dtype=self.dtype)
+            motion_style = model.style_encoder(style_motion).detach()
+            motion_style_cond = model.style_cond_embed(motion_style)[:, None]
+            motion_style_cond = motion_style_cond * 1.1 - model.null_style_cond * 0.1
+        else:
+            motion_style_cond = model.null_style_cond
+        self._motion_style_cond = motion_style_cond
+
+    @torch.no_grad()
+    def reset(self):
+        model = self.model
+        prev_motion = torch.zeros(
+            1, self.frames_per_chunk, self.motion_dim,
+            dtype=self.dtype, device=self.device,
+        )
+        prev_code_bits, _ = model.basic_vae.quant_to_vqidx(prev_motion, this_motion=None)
+        prev_vqfeat = model.basic_vae.vqidx_to_ms_vqfeat(prev_code_bits)
+        prev_attn_feat = torch.cat(
+            [self._motion_style_cond, model.vqfeat_embed(prev_vqfeat)], dim=1,
+        ).repeat(1, model.prev_ratio, 1)
+        self._prev_code_bits = prev_code_bits
+        self._prev_attn_feat = prev_attn_feat
+        self._audio_buffer = torch.zeros(0, dtype=self.dtype, device=self.device)
+
+    @torch.no_grad()
+    def feed(self, audio):
+        if audio.dim() != 1:
+            raise ValueError(f"audio must be 1-D, got shape {tuple(audio.shape)}")
+        audio = audio.to(device=self.device, dtype=self.dtype)
+        self._audio_buffer = torch.cat([self._audio_buffer, audio])
+
+        outputs = []
+        while self._audio_buffer.shape[0] >= self.patch_audio_length:
+            chunk = self._audio_buffer[: self.patch_audio_length]
+            self._audio_buffer = self._audio_buffer[self.patch_audio_length:]
+            outputs.append(self._step_chunk(chunk[None]))
+        if outputs:
+            return torch.cat(outputs, dim=0)
+        return torch.zeros(0, self.motion_dim, dtype=self.dtype, device=self.device)
+
+    @torch.no_grad()
+    def finish(self):
+        valid_samples = self._audio_buffer.shape[0]
+        if valid_samples == 0:
+            return torch.zeros(0, self.motion_dim, dtype=self.dtype, device=self.device)
+        valid_frames = math.ceil(valid_samples / SAMPLE_RATE * FPS)
+        pad = self.patch_audio_length - valid_samples
+        chunk = torch.cat([
+            self._audio_buffer,
+            torch.zeros(pad, dtype=self.dtype, device=self.device),
+        ])
+        self._audio_buffer = self._audio_buffer.new_zeros(0)
+        motion = self._step_chunk(chunk[None])
+        return motion[:valid_frames]
+
+    @torch.no_grad()
+    def _step_chunk(self, audio_chunk):
+        model = self.model
+        lvl_pos_embed = model.lvl_embed(model.lvl_idx) + model.pos_embed
+        prev_lvl_pos_embed = (
+            model.lvl_embed(model.lvl_idx).repeat(1, model.prev_ratio, 1)
+            + model.prev_pos_embed
+        )
+
+        split_audio_feat = model.audio_encoder(audio_chunk).permute(0, 2, 1)
+        split_audio_feats = [
+            F.interpolate(split_audio_feat, size=(pn), mode="area").permute(0, 2, 1)
+            for pn in model.patch_nums
+        ]
+        split_audio_cond = torch.cat(split_audio_feats, dim=1).detach()
+
+        next_ar_vqfeat = self._motion_style_cond
+        pred_motion_bits = None
+        for pidx, _pn in enumerate(model.patch_nums):
+            patch_audio_cond = split_audio_cond[:, : sum(model.patch_nums[: pidx + 1])]
+            patch_attn_bias = model.attn_bias_for_masking[
+                :,
+                :,
+                : sum(model.patch_nums[: pidx + 1]),
+                : sum(model.patch_nums[: pidx + 1])
+                + sum(model.patch_nums) * model.prev_ratio,
+            ]
+            attn_feat = next_ar_vqfeat + lvl_pos_embed[:, : next_ar_vqfeat.shape[1]]
+            for bidx in range(model.attn_depth):
+                attn_feat = model.attn_blocks[bidx](
+                    attn_feat,
+                    self._prev_attn_feat + prev_lvl_pos_embed,
+                    patch_audio_cond,
+                    attn_bias=patch_attn_bias,
+                )
+            pred_motion_logits = model.logits_head(
+                model.cond_logits_head(attn_feat, patch_audio_cond)
+            )
+            pred_motion_bits = pred_motion_logits.view(
+                pred_motion_logits.shape[0], pred_motion_logits.shape[1], -1, 2,
+            ).argmax(dim=-1)
+            if pidx < len(model.patch_nums) - 1:
+                next_ar_vqfeat = model.basic_vae.vqidx_to_ar_vqfeat(
+                    pidx,
+                    pred_motion_bits,
+                )
+                next_ar_vqfeat = torch.cat(
+                    [self._motion_style_cond, model.vqfeat_embed(next_ar_vqfeat)],
+                    dim=1,
+                )
+
+        _, this_pred_motion = model.basic_vae.vqidx_to_motion(
+            self._prev_code_bits, pred_motion_bits
+        )
+
+        new_prev_code_bits, _ = model.basic_vae.quant_to_vqidx(
+            this_pred_motion,
+            this_motion=None,
+        )
+        new_prev_vqfeat = (
+            model.basic_vae.vqidx_to_ms_vqfeat(new_prev_code_bits).detach()
+        )
+        this_prev_attn_feat = torch.cat(
+            [self._motion_style_cond, model.vqfeat_embed(new_prev_vqfeat)], dim=1,
+        )
+        new_prev_attn_feat = torch.cat(
+            [
+                self._prev_attn_feat[:, this_prev_attn_feat.shape[1]:],
+                this_prev_attn_feat,
+            ],
+            dim=1,
+        )
+
+        self._prev_code_bits = new_prev_code_bits
+        self._prev_attn_feat = new_prev_attn_feat
+
+        return this_pred_motion[0]
+
+
+class CausalSavgolSmoother:
+    """Streaming counterpart of ``ARTAvatarInferEngine.smooth_motion_savgol``.
+
+    The one-shot smoother applies ``scipy.signal.savgol_filter`` over
+    the full motion sequence in two passes:
+
+      * all 106 channels: ``window_length=5``, ``polyorder=2``
+      * pose channels (``[100:103]``) override: ``window_length=9``,
+        ``polyorder=3``
+
+    Savgol with the default ``mode='interp'`` is deterministic and
+    local, so the streaming output is **bit-exact** with the one-shot
+    path while filtering only a small window per feed: interior frames
+    depend only on ``DELAY`` frames of context on each side, and the
+    edge-fitted boundary frames are computed from slices whose edges
+    coincide with the true sequence edges (the first frames are emitted
+    from a slice starting at frame 0; ``finish()`` filters a slice that
+    contains the final ``POSE_WINDOW`` frames). Frames that can no
+    longer influence any future output are dropped, so per-feed cost
+    and retained memory stay bounded regardless of session length.
+
+    Each emitted frame is delayed by ``(POSE_WINDOW - 1) // 2 = 4``
+    frames (160 ms at 25 fps), on top of the AR model's 4-second chunk
+    lag.
+
+    See ``docs/realtime.md`` for the alternative approaches that were
+    considered (causal IIR/EMA, no smoothing) and why this one was
+    chosen.
+    """
+
+    POSE_SLICE = slice(100, 103)
+    DEFAULT_WINDOW = 5
+    DEFAULT_POLY = 2
+    POSE_WINDOW = 9
+    POSE_POLY = 3
+    DELAY = (POSE_WINDOW - 1) // 2
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        # ``_tail`` holds frames [``_tail_start``, n_seen) — the suffix of
+        # the full sequence that can still influence future output.
+        self._tail = None
+        self._tail_start = 0
+        self._n_emitted = 0
+
+    def _n_seen(self):
+        return self._tail_start + self._tail.shape[0]
+
+    def feed(self, motion_frames):
+        if motion_frames.dim() != 2:
+            raise ValueError(
+                f"motion_frames must be 2-D (T, C), got shape {tuple(motion_frames.shape)}"
+            )
+        if motion_frames.shape[0] == 0:
+            return motion_frames
+        if self._tail is None:
+            self._tail = motion_frames
+        else:
+            self._tail = torch.cat([self._tail, motion_frames], dim=0)
+        n_seen = self._n_seen()
+        empty = motion_frames.new_zeros(0, motion_frames.shape[1])
+        if n_seen < self.POSE_WINDOW:
+            return empty
+        n_stable = n_seen - self.DELAY
+        if n_stable <= self._n_emitted:
+            return empty
+        out = self._smooth_range(self._n_emitted, n_stable)
+        self._n_emitted = n_stable
+        # Future output needs DELAY frames of context before the next
+        # emitted frame, and finish() needs the last POSE_WINDOW frames
+        # for its right-edge polynomial fit.
+        keep_from = min(self._n_emitted - self.DELAY, n_seen - self.POSE_WINDOW)
+        if keep_from > self._tail_start:
+            self._tail = self._tail[keep_from - self._tail_start :]
+            self._tail_start = keep_from
+        return out
+
+    def finish(self):
+        if self._tail is None:
+            raise RuntimeError(
+                "CausalSavgolSmoother.finish called before any feed; "
+                "no motion_dim known."
+            )
+        n_seen = self._n_seen()
+        if self._n_emitted >= n_seen:
+            out = self._tail.new_zeros(0, self._tail.shape[1])
+        elif n_seen < self.POSE_WINDOW:
+            # Buffer too short to apply the 9-tap pose filter.
+            # Fall back to raw frames; one-shot inference would also
+            # fail on inputs this short.
+            out = self._tail[self._n_emitted - self._tail_start :]
+        else:
+            out = self._smooth_range(self._n_emitted, n_seen)
+        self._n_emitted = n_seen
+        return out
+
+    def _smooth_range(self, start, end):
+        """Smoothed frames [``start``, ``end``), bit-exact with filtering
+        the full sequence."""
+        n_seen = self._n_seen()
+        lo = max(start - self.DELAY, 0)
+        if end > n_seen - self.DELAY:
+            # The range includes right-boundary frames, whose edge fit
+            # must see the true final POSE_WINDOW frames.
+            lo = min(lo, max(n_seen - self.POSE_WINDOW, 0))
+        smoothed = self._apply_savgol(self._tail[lo - self._tail_start :])
+        return smoothed[start - lo : end - lo]
+
+    @classmethod
+    def _apply_savgol(cls, buffer):
+        motion_np = buffer.detach().cpu().numpy()
+        smoothed = savgol_filter(
+            motion_np, cls.DEFAULT_WINDOW, cls.DEFAULT_POLY, axis=0,
+        )
+        smoothed[..., cls.POSE_SLICE] = savgol_filter(
+            motion_np[..., cls.POSE_SLICE],
+            cls.POSE_WINDOW, cls.POSE_POLY, axis=0,
+        )
+        return torch.from_numpy(smoothed).to(
+            device=buffer.device,
+            dtype=buffer.dtype,
+        )

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -1,0 +1,83 @@
+# Realtime streaming notes
+
+Design notes for the streaming-friendly extension of ARTalk inference
+(roadmap: [#30](https://github.com/xg-chu/ARTalk/issues/30)).
+
+## Constraints
+
+The released model processes audio in fixed 4-second / 100-frame chunks.
+Multi-scale autoregressive decoding within each chunk depends on the
+full chunk being available, so end-to-end latency cannot drop below
+~4 seconds without architectural changes to the AR model (smaller
+`patch_nums`, causal redesign, etc.). All streaming work preserves the
+released checkpoints bit-for-bit unchanged; latency reductions below
+the 4-second floor would require coordinated retraining work.
+
+## Streaming inference — `ARTalkStreamer`
+
+Refactors `BitwiseARModel.inference`'s chunked audio loop into a
+stateful feed/finish API in `artalk/streaming.py`. The model itself and
+the existing one-shot inference path are untouched, so the released
+checkpoint and the CLI / Gradio app continue to work unchanged.
+
+`scripts/check_streaming_parity.py` asserts the streaming output is
+bit-exact with the one-shot path. Verified on the released wav2vec
+checkpoint: `max abs diff: 0.000e+00`.
+
+## Causal motion smoother — `CausalSavgolSmoother`
+
+Streaming-friendly equivalent of the post-processing in
+`ARTAvatarInferEngine.smooth_motion_savgol` (scipy `savgol_filter` over
+the full motion sequence — non-causal).
+
+### Design decisions
+
+Three approaches were considered:
+
+- **Delayed savgol.** Buffer future motion frames and emit each
+  output with `(POSE_WINDOW - 1) // 2 = 4` frames (160 ms at 25 fps)
+  of additional latency. Re-running scipy's `savgol_filter` on the
+  growing buffer yields output that is **bit-exact** with the
+  one-shot path: `mode='interp'` (the scipy default) is deterministic,
+  and interior frames depend only on a fixed `window`-sized
+  neighborhood that becomes context-independent once both halves of
+  the window are in the buffer.
+- **Causal IIR / EMA.** One-pole low-pass filter applied to past
+  samples only. Zero added latency, but the frequency response
+  differs from savgol; output values would not match the one-shot
+  reference.
+- **No smoothing.** The original smoother is cosmetic; some use
+  cases may not need it.
+
+**Choice: delayed savgol.** The 160 ms added latency is small relative
+to the 4-second chunk floor, and bit-exact output keeps the smoother
+from being a confounding variable when verifying the later streaming
+stages. "No smoothing" remains available as a simple opt-out at the
+call site (do not run motion through the smoother). The causal IIR
+option is recorded for reference; it would be considered together with
+retraining work since it would not be bit-exact regardless.
+
+Other engine post-processing (eye-channel zeroing, `fix_pose`,
+`clip_length` truncation) is not streaming-aware and stays at the
+engine layer.
+
+## Planned follow-ups
+
+Per the [roadmap](https://github.com/xg-chu/ARTalk/issues/30): a
+per-frame streaming renderer mirroring the mesh / GAGAvatar branches of
+`ARTAvatarInferEngine.rendering`, and a realtime pipeline that wires
+`ARTalkStreamer → CausalSavgolSmoother → renderer` behind
+audio-clock-synchronized output callbacks. A WebRTC application layer
+built on these pieces lives in
+[artalk-streamlit-realtime](https://github.com/whitphx/artalk-streamlit-realtime).
+
+## Future (deferred)
+
+- **Architectural latency reduction below the 4-second floor.** Smaller
+  `patch_nums`, causal AR redesign, etc. Requires retraining and
+  coordination with the original author.
+- **Client-side rendering.** Push raw 106-dim motion params over the
+  wire instead of rendered video and implement FLAME / GAGAvatar
+  equivalents in the browser (Three.js + Gaussian splat). Drastically
+  reduces server load and bandwidth, and decouples the rendering
+  pipeline from the inference server.

--- a/scripts/check_streaming_parity.py
+++ b/scripts/check_streaming_parity.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""Parity checks for the streaming inference / post-processing pieces.
+
+Loads the released ARTalk wav2vec checkpoint and runs:
+
+  1. **Streaming inference** — feeds the same audio to
+     ``BitwiseARModel.inference`` (one-shot) and to ``ARTalkStreamer``
+     (chunked, arbitrary feed sizes), and asserts the motion outputs
+     match within ``--atol``.
+
+  2. **Streaming smoother** — applies
+     ``ARTAvatarInferEngine.smooth_motion_savgol`` (one-shot) and
+     ``CausalSavgolSmoother`` (streaming) to the same motion sequence,
+     and asserts the outputs match within ``--atol``.
+
+Run on a GPU host where the model and ``./assets`` are available:
+
+    python -m scripts.check_streaming_parity [-a demo/eng1.wav] [--device cuda]
+
+(or ``PYTHONPATH=. python scripts/check_streaming_parity.py ...``)
+"""
+
+import argparse
+import json
+
+import torch
+import torchaudio
+from scipy.signal import savgol_filter
+
+from artalk import BitwiseARModel
+from artalk.streaming import ARTalkStreamer, CausalSavgolSmoother
+
+
+def smooth_motion_savgol_reference(motion_codes):
+    """One-shot reference: mirror of ``ARTAvatarInferEngine.smooth_motion_savgol``."""
+    motion_np = motion_codes.clone().detach().cpu().numpy()
+    motion_np_smoothed = savgol_filter(motion_np, window_length=5, polyorder=2, axis=0)
+    motion_np_smoothed[..., 100:103] = savgol_filter(
+        motion_np[..., 100:103], window_length=9, polyorder=3, axis=0
+    )
+    return torch.tensor(motion_np_smoothed).type_as(motion_codes)
+
+
+def run_streamer(streamer, audio, feed_chunk_samples):
+    pieces = []
+    for i in range(0, audio.shape[0], feed_chunk_samples):
+        out = streamer.feed(audio[i : i + feed_chunk_samples])
+        if out.shape[0] > 0:
+            pieces.append(out)
+    tail = streamer.finish()
+    if tail.shape[0] > 0:
+        pieces.append(tail)
+    return torch.cat(pieces, dim=0) if pieces else None
+
+
+def run_smoother(smoother, motion, feed_chunk_frames):
+    pieces = []
+    for i in range(0, motion.shape[0], feed_chunk_frames):
+        out = smoother.feed(motion[i : i + feed_chunk_frames])
+        if out.shape[0] > 0:
+            pieces.append(out)
+    tail = smoother.finish()
+    if tail.shape[0] > 0:
+        pieces.append(tail)
+    return torch.cat(pieces, dim=0) if pieces else None
+
+
+def assert_match(reference, streamed, atol, label):
+    print(f"[{label}] one_shot: {tuple(reference.shape)}, streamed: {tuple(streamed.shape)}")
+    assert reference.shape == streamed.shape, f"[{label}] shape mismatch"
+    diff = (reference - streamed).abs()
+    print(f"[{label}] max abs diff:  {diff.max().item():.3e}")
+    print(f"[{label}] mean abs diff: {diff.mean().item():.3e}")
+    if not torch.allclose(reference, streamed, atol=atol):
+        raise SystemExit(f"[{label}] diverges beyond atol={atol}")
+    print(f"[{label}] OK")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--audio", "-a", default="./demo/eng1.wav", type=str)
+    parser.add_argument("--device", default="cuda", type=str)
+    parser.add_argument(
+        "--feed-chunk-samples",
+        type=int,
+        default=4000,
+        help="audio chunk size fed to ARTalkStreamer (samples @16kHz). "
+             "Choose != patch_audio_length so audio buffering is exercised.",
+    )
+    parser.add_argument(
+        "--smoother-feed-chunk-frames",
+        type=int,
+        default=7,
+        help="motion chunk size fed to CausalSavgolSmoother (frames @25fps). "
+             "Choose a small odd number to exercise sub-window feeds.",
+    )
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument(
+        "--audio-encoder", default="wav2vec", type=str,
+        help="ARTalk audio encoder architecture name.",
+    )
+    parser.add_argument(
+        "--checkpoint", default=None, type=str,
+        help="checkpoint path override (default: ./assets/ARTalk_<audio-encoder>.pt)",
+    )
+    parser.add_argument(
+        "--style", default=None, type=str,
+        help="optional style id under assets/style_motion (e.g. natural_0)",
+    )
+    args = parser.parse_args()
+
+    device = args.device
+    audio_encoder = args.audio_encoder
+
+    checkpoint_path = args.checkpoint or f"./assets/ARTalk_{audio_encoder}.pt"
+    print(f"checkpoint: {checkpoint_path} (audio encoder: {audio_encoder})")
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+    configs = json.load(open("./assets/config.json"))
+    configs["AR_CONFIG"]["AUDIO_ENCODER"] = audio_encoder
+    model = BitwiseARModel(configs).to(device)
+    model.train(False)
+    model.load_state_dict(ckpt, strict=True)
+
+    style_motion = None
+    if args.style is not None:
+        style_motion = torch.load(
+            f"./assets/style_motion/{args.style}.pt", map_location="cpu", weights_only=True
+        )
+
+    audio, sr = torchaudio.load(args.audio)
+    audio = torchaudio.transforms.Resample(sr, 16000)(audio).mean(dim=0).to(device)
+    print(f"audio: {audio.shape[0]} samples ({audio.shape[0] / 16000:.2f}s)")
+
+    batch = {"audio": audio[None]}
+    if style_motion is not None:
+        batch["style_motion"] = style_motion[None].to(device)
+    one_shot_motion = model.inference(batch)[0]
+
+    # Streaming inference parity.
+    streamer = ARTalkStreamer(model, style_motion=style_motion)
+    streamed_motion = run_streamer(streamer, audio, args.feed_chunk_samples)
+    assert streamed_motion is not None, "streamer produced no output"
+    assert_match(one_shot_motion, streamed_motion, args.atol, "streaming inference")
+
+    # Streaming smoother parity (against one-shot smoother).
+    one_shot_smoothed = smooth_motion_savgol_reference(one_shot_motion)
+    smoother = CausalSavgolSmoother()
+    streamed_smoothed = run_smoother(
+        smoother, one_shot_motion, args.smoother_feed_chunk_frames
+    )
+    assert streamed_smoothed is not None, "smoother produced no output"
+    assert_match(one_shot_smoothed, streamed_smoothed, args.atol, "streaming smoother")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of the realtime roadmap in #30. This adds the first two streaming building blocks as a new `artalk/streaming.py` module, leaving the released checkpoints and the existing one-shot inference path (CLI / Gradio app) completely untouched.

## What's included

- **`ARTalkStreamer`** — exposes `BitwiseARModel.inference`'s chunked audio loop as a stateful `feed()` / `finish()` API. The model already processes audio in fixed 4-second / 100-frame chunks internally, and the only state crossing chunk boundaries is the previous code bits plus the rolling attention-feature buffer; the streamer carries exactly that state so callers can feed audio in arbitrary-sized pieces as it arrives.
- **`CausalSavgolSmoother`** — a streaming counterpart to `ARTAvatarInferEngine.smooth_motion_savgol`. It buffers 4 frames (160 ms at 25 fps) of lookahead, which is enough for scipy's `savgol_filter` (with its default `mode='interp'`) to produce output identical to filtering the full sequence at once. Memory and per-feed cost stay bounded regardless of session length.
- **`scripts/check_streaming_parity.py`** — asserts both properties against the one-shot reference implementations.
- **`docs/realtime.md`** — design notes: the 4-second latency floor, and the smoother alternatives considered (causal IIR/EMA, no smoothing) with the reasoning for the chosen approach.

## Verification

Both checks are **bit-exact** against the one-shot paths on the released wav2vec checkpoint (`max abs diff: 0.000e+00`), verified in two configurations — default, and with a style motion (`--style natural_0`) plus deliberately odd feed-chunk sizes to exercise the audio/motion buffering edges:

```
PYTHONPATH=. python scripts/check_streaming_parity.py --device cuda
[streaming inference] max abs diff:  0.000e+00
[streaming inference] OK
[streaming smoother] max abs diff:  0.000e+00
[streaming smoother] OK
```

Follow-ups per the roadmap: a per-frame streaming renderer mirroring the mesh / GAGAvatar branches of `ARTAvatarInferEngine.rendering`, then the realtime pipeline that wires these stages together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)