### PR TITLE
Add a streaming renderer for motion frames

### DIFF
--- a/artalk/__init__.py
+++ b/artalk/__init__.py
@@ -3,4 +3,6 @@
 
 from .assets import ARTalkAssets
 from .models import BitwiseARModel
+from .rendering import StreamingRenderer
 from .runtime import ARTalkResult, ARTalkRuntime, ARTalkRuntimeConfig
+from .streaming import ARTalkStreamer, CausalSavgolSmoother

--- a/artalk/rendering.py
+++ b/artalk/rendering.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+# Copyright (c) Xuangeng Chu (xg.chu@outlook.com)
+
+"""Streaming renderer for motion → RGB.
+
+Streaming counterpart to ``ARTAvatarInferEngine.rendering``. The
+one-shot path collects all frames in a list and muxes them with audio
+into an MP4; this class renders motion frames as they arrive and
+returns RGB tensors. Audio/video muxing is left to the caller's
+transport layer.
+
+Two modes mirror the one-shot paths:
+
+* ``'mesh'`` — FLAME mesh render at 512x512.
+* ``'gagavatar'`` — GAGAvatar Gaussian-splat render of a tracked
+  real avatar.
+
+The renderer accepts the FLAME / GAGAvatar components as constructor
+arguments rather than loading them itself, so callers can share an
+``ARTAvatarInferEngine``'s already-loaded modules without paying the
+init cost twice.
+
+See ``docs/realtime.md`` for the design rationale, including why the
+existing one-shot ``rendering()`` is kept untouched and why "raw
+motion params output" is not a renderer mode (callers that want to
+skip server-side rendering simply consume motion frames before this
+stage).
+"""
+
+import torch
+
+
+def _module_device(module):
+    # FLAMEModel holds only registered buffers, no trainable parameters.
+    for tensor in module.parameters():
+        return tensor.device
+    for tensor in module.buffers():
+        return tensor.device
+    raise ValueError(
+        f"cannot infer device from {type(module).__name__}; pass device="
+    )
+
+
+class StreamingRenderer:
+    def __init__(
+        self,
+        mode,
+        *,
+        basic_vae=None,
+        flame_model=None,
+        mesh_renderer=None,
+        shape_code=None,
+        gagavatar=None,
+        gagavatar_flame=None,
+        shape_id=None,
+        device=None,
+        output_uint8=False,
+    ):
+        if mode == "mesh":
+            if basic_vae is None or flame_model is None or mesh_renderer is None:
+                raise ValueError(
+                    "mode='mesh' requires basic_vae, flame_model, mesh_renderer"
+                )
+            if device is None:
+                device = _module_device(flame_model)
+            if shape_code is None:
+                shape_code = torch.zeros(1, 300, device=device)
+            else:
+                if shape_code.dim() != 2 or shape_code.shape[0] != 1:
+                    raise ValueError(
+                        f"shape_code must be (1, 300), got {tuple(shape_code.shape)}"
+                    )
+                shape_code = shape_code.to(device)
+            self._render = self._render_mesh
+            self._render_batch = self._render_mesh_batch
+            self._mesh_basic_vae = basic_vae
+            self._mesh_flame = flame_model
+            self._mesh_renderer = mesh_renderer
+            self._mesh_shape_code = shape_code
+        elif mode == "gagavatar":
+            if gagavatar is None or gagavatar_flame is None or shape_id is None:
+                raise ValueError(
+                    "mode='gagavatar' requires gagavatar, gagavatar_flame, shape_id"
+                )
+            if device is None:
+                device = _module_device(gagavatar_flame)
+            gagavatar.set_avatar_id(shape_id)
+            self._render = self._render_gagavatar
+            self._render_batch = self._render_gagavatar_batch
+            self._gaga = gagavatar
+            self._gaga_flame = gagavatar_flame
+        else:
+            raise ValueError(f"Unknown mode: {mode!r}")
+        self.mode = mode
+        self._device = device
+        # Scale/clamp/permute to HWC uint8 on the GPU before the
+        # device-to-host copy: 4x less PCIe traffic than float32 and no
+        # CPU-side conversion. Batch outputs are then (T, H, W, 3) uint8
+        # instead of (T, 3, H, W) float.
+        self._output_uint8 = bool(output_uint8)
+
+    @property
+    def device(self):
+        return self._device
+
+    @torch.no_grad()
+    def render_frame(self, motion_frame):
+        """Render one motion frame.
+
+        ``motion_frame``: 1-D tensor of shape (motion_dim,) — typically
+        (106,). Returns a (3, H, W) ``torch.float32`` tensor on CPU
+        with values in [0, 1].
+        """
+        if motion_frame.dim() != 1:
+            raise ValueError(
+                f"motion_frame must be 1-D, got shape {tuple(motion_frame.shape)}"
+            )
+        return self._render(motion_frame.to(self._device))
+
+    @torch.no_grad()
+    def render_batch(self, motion_frames):
+        """Render a motion batch in one model invocation.
+
+        ``motion_frames``: 2-D tensor of shape (T, motion_dim). Returns
+        a (T, 3, H, W) ``torch.float32`` tensor on CPU with values in
+        [0, 1], or (T, H, W, 3) ``torch.uint8`` with ``output_uint8``.
+
+        In ``'gagavatar'`` mode this requires a batch-capable
+        ``gagavatar`` implementation (the packaged ``gagavatar``
+        runtime); the copy vendored under ``artalk/GAGAvatar`` builds
+        forward batches one frame at a time — use ``render_frame`` /
+        ``feed`` with it.
+        """
+        if motion_frames.dim() != 2:
+            raise ValueError(
+                f"motion_frames must be 2-D, got shape {tuple(motion_frames.shape)}"
+            )
+        return self._render_batch(motion_frames.to(self._device))
+
+    @torch.no_grad()
+    def feed(self, motion_frames):
+        """Iterate over (T, motion_dim) and yield per-frame RGB tensors."""
+        if motion_frames.dim() != 2:
+            raise ValueError(
+                f"motion_frames must be 2-D, got shape {tuple(motion_frames.shape)}"
+            )
+        for i in range(motion_frames.shape[0]):
+            yield self.render_frame(motion_frames[i])
+
+    def _batch_to_output(self, rgb_batch):
+        if not self._output_uint8:
+            return rgb_batch.cpu()
+        return (
+            (rgb_batch * 255.0)
+            .clamp_(0, 255)
+            .to(torch.uint8)
+            .permute(0, 2, 3, 1)
+            .contiguous()
+            .cpu()
+        )
+
+    def _render_mesh(self, motion_frame):
+        verts = self._mesh_basic_vae.get_flame_verts(
+            self._mesh_flame,
+            self._mesh_shape_code,
+            motion_frame[None],
+            with_global=True,
+        )
+        rgb = self._mesh_renderer(verts)[0]
+        return rgb.cpu()[0] / 255.0
+
+    def _render_mesh_batch(self, motion_frames):
+        shape_code = self._mesh_shape_code.expand(motion_frames.shape[0], -1)
+        verts = self._mesh_basic_vae.get_flame_verts(
+            self._mesh_flame,
+            shape_code,
+            motion_frames,
+            with_global=True,
+        )
+        rgb = self._mesh_renderer(verts)[0] / 255.0
+        return self._batch_to_output(rgb)
+
+    def _render_gagavatar(self, motion_frame):
+        batch = self._gaga.build_forward_batch(motion_frame[None], self._gaga_flame)
+        rgb = self._gaga.forward_expression(batch)
+        return rgb.cpu()[0]
+
+    def _render_gagavatar_batch(self, motion_frames):
+        batch = self._gaga.build_forward_batch(motion_frames, self._gaga_flame)
+        rgb = self._gaga.forward_expression(batch)
+        return self._batch_to_output(rgb)

--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -61,12 +61,72 @@ Other engine post-processing (eye-channel zeroing, `fix_pose`,
 `clip_length` truncation) is not streaming-aware and stays at the
 engine layer.
 
+## Streaming rendering — `StreamingRenderer`
+
+`StreamingRenderer` in `artalk/rendering.py` mirrors the mesh /
+GAGAvatar branches of `ARTAvatarInferEngine.rendering` as a streaming
+API: `render_frame(motion_frame) → (3, H, W)` RGB tensor on CPU in
+[0, 1] range, plus `render_batch(motion_frames)` for rendering several
+frames per model invocation. Audio/video muxing is no longer the
+renderer's responsibility — it moves to the caller's transport layer.
+
+### Design decisions
+
+- **Single class with mode dispatch**, not separate per-mode classes.
+  Mirrors the existing one-shot `rendering()`'s `shape_id`-based
+  dispatch and lets config-driven callers construct uniformly.
+- **New file `artalk/rendering.py`**, not a subsection of
+  `artalk/streaming.py`. Streaming-specific motion logic
+  (`ARTalkStreamer`, `CausalSavgolSmoother`) stays focused there;
+  rendering is a separate concern with different dependencies (FLAME
+  / GAGAvatar).
+- **Existing one-shot `ARTAvatarInferEngine.rendering()` is left
+  untouched.** A small amount of per-frame logic is duplicated
+  between the two paths in exchange for keeping the diff minimal; the
+  original CLI / Gradio app continues to work unchanged.
+- **No "raw motion params" mode on the renderer.** Clients that
+  want to ship motion params instead of rendered video simply skip
+  the renderer stage and consume motion frames directly from
+  `CausalSavgolSmoother` (or `ARTalkStreamer`). Adding a passthrough
+  mode would have been a thin abstraction that doesn't earn its name.
+- **Renderer takes loaded modules as constructor args**, not paths.
+  Typical callers pass the modules `ARTAvatarInferEngine` already
+  loaded; tests can construct the FLAME pieces directly without
+  spinning up a full engine.
+
+`scripts/check_streaming_parity.py` adds mesh-mode parity checks for
+both the per-frame and batched paths (skipped automatically if
+`assets/FLAME_with_eye.pt` is not present). The GAGAvatar path is not
+covered by automated parity because of the asset-download cost; verify
+it with a smoke test if needed.
+
+### Parity criterion (mesh)
+
+The streaming inference and smoother stages produce **bit-exact**
+output between streaming and one-shot. Mesh rendering does not, and
+cannot:
+
+- `get_flame_verts` runs FLAME's linear-blend-skinning either over
+  the full batch `T` (one-shot) or `T` times over batch `1`
+  (streaming). Float32 add non-associativity makes vertex
+  coordinates diverge at the ~1e-7 level depending on reduction
+  order.
+- Those tiny vertex deltas feed a discrete rasterizer, which makes
+  binary coverage decisions at silhouette edges. A 1–2 pixel
+  silhouette outline can flip individual pixels.
+
+In practice this manifests as `mean abs diff ~ 2e-8` with
+`max abs diff ~ 6e-1` on a 13-second clip. The parity test therefore
+asserts **mean abs diff < 1e-5 AND <0.1% of pixels diverge by more
+than 1e-2**, instead of strict element-wise equality. Streaming
+output is "visually identical" to one-shot, not bit-identical, and
+that is the right notion of equivalence for this stage.
+
 ## Planned follow-ups
 
 Per the [roadmap](https://github.com/xg-chu/ARTalk/issues/30): a
-per-frame streaming renderer mirroring the mesh / GAGAvatar branches of
-`ARTAvatarInferEngine.rendering`, and a realtime pipeline that wires
-`ARTalkStreamer → CausalSavgolSmoother → renderer` behind
+realtime pipeline that wires
+`ARTalkStreamer → CausalSavgolSmoother → StreamingRenderer` behind
 audio-clock-synchronized output callbacks. A WebRTC application layer
 built on these pieces lives in
 [artalk-streamlit-realtime](https://github.com/whitphx/artalk-streamlit-realtime).

--- a/scripts/check_streaming_parity.py
+++ b/scripts/check_streaming_parity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Parity checks for the streaming inference / post-processing pieces.
+"""Parity checks for the streaming inference / post-processing / rendering pieces.
 
 Loads the released ARTalk wav2vec checkpoint and runs:
 
@@ -13,6 +13,12 @@ Loads the released ARTalk wav2vec checkpoint and runs:
      ``CausalSavgolSmoother`` (streaming) to the same motion sequence,
      and asserts the outputs match within ``--atol``.
 
+  3. **Streaming mesh rendering** — renders motion frames via
+     ``StreamingRenderer`` (per-frame and batched) and via the inline
+     mesh branch of ``ARTAvatarInferEngine.rendering``, and asserts
+     the RGB outputs match within an image-level tolerance. Skipped if
+     ``assets/FLAME_with_eye.pt`` is not present.
+
 Run on a GPU host where the model and ``./assets`` are available:
 
     python -m scripts.check_streaming_parity [-a demo/eng1.wav] [--device cuda]
@@ -22,13 +28,17 @@ Run on a GPU host where the model and ``./assets`` are available:
 
 import argparse
 import json
+import os
 
 import torch
 import torchaudio
 from scipy.signal import savgol_filter
 
 from artalk import BitwiseARModel
+from artalk.rendering import StreamingRenderer
 from artalk.streaming import ARTalkStreamer, CausalSavgolSmoother
+
+FLAME_ASSET_PATH = "./assets/FLAME_with_eye.pt"
 
 
 def smooth_motion_savgol_reference(motion_codes):
@@ -65,6 +75,19 @@ def run_smoother(smoother, motion, feed_chunk_frames):
     return torch.cat(pieces, dim=0) if pieces else None
 
 
+def render_mesh_oneshot_reference(motion, basic_vae, flame_model, mesh_renderer):
+    """One-shot reference: mesh branch of ``ARTAvatarInferEngine.rendering``."""
+    shape_code = motion.new_zeros(1, 300).expand(motion.shape[0], -1)
+    verts = basic_vae.get_flame_verts(
+        flame_model, shape_code, motion, with_global=True
+    )
+    pred_images = []
+    for v in verts:
+        rgb = mesh_renderer(v[None])[0]
+        pred_images.append(rgb.cpu()[0] / 255.0)
+    return torch.stack(pred_images, dim=0)
+
+
 def assert_match(reference, streamed, atol, label):
     print(f"[{label}] one_shot: {tuple(reference.shape)}, streamed: {tuple(streamed.shape)}")
     assert reference.shape == streamed.shape, f"[{label}] shape mismatch"
@@ -74,6 +97,55 @@ def assert_match(reference, streamed, atol, label):
     if not torch.allclose(reference, streamed, atol=atol):
         raise SystemExit(f"[{label}] diverges beyond atol={atol}")
     print(f"[{label}] OK")
+
+
+def assert_match_render(
+    reference,
+    streamed,
+    label,
+    mean_atol=1e-5,
+    sparse_pixel_atol=1e-2,
+    sparse_pixel_max_fraction=1e-3,
+):
+    """Image-tolerant parity check for mesh rendering.
+
+    Mesh rendering is not bit-exact between one-shot (FLAME LBS over
+    a batch of T) and streaming (T calls over batch 1): float32 add
+    non-associativity at ~1e-7 in vertex coordinates feeds discrete
+    rasterizer coverage decisions, flipping a 1-2 pixel silhouette
+    outline. The mean is expected to be near zero; a small fraction
+    of silhouette pixels may diverge significantly. See
+    ``docs/realtime.md``.
+    """
+    print(f"[{label}] one_shot: {tuple(reference.shape)}, streamed: {tuple(streamed.shape)}")
+    assert reference.shape == streamed.shape, f"[{label}] shape mismatch"
+    diff = (reference - streamed).abs()
+    mean_diff = diff.mean().item()
+    max_diff = diff.max().item()
+    print(f"[{label}] max abs diff:  {max_diff:.3e}")
+    print(f"[{label}] mean abs diff: {mean_diff:.3e}")
+
+    n_total = diff.numel()
+    n_sparse = int((diff > sparse_pixel_atol).sum().item())
+    sparse_fraction = n_sparse / n_total
+    print(
+        f"[{label}] pixels with diff > {sparse_pixel_atol:.0e}: "
+        f"{n_sparse}/{n_total} ({sparse_fraction*100:.4f}%)"
+    )
+
+    if mean_diff > mean_atol:
+        raise SystemExit(
+            f"[{label}] mean diff {mean_diff:.3e} exceeds {mean_atol:.0e}"
+        )
+    if sparse_fraction > sparse_pixel_max_fraction:
+        raise SystemExit(
+            f"[{label}] {sparse_fraction*100:.4f}% of pixels diverge beyond "
+            f"{sparse_pixel_atol:.0e}, exceeds {sparse_pixel_max_fraction*100:.4f}%"
+        )
+    print(
+        f"[{label}] OK (mean<{mean_atol:.0e}, "
+        f"sparse pixel divergence within tolerance)"
+    )
 
 
 def main():
@@ -95,6 +167,12 @@ def main():
              "Choose a small odd number to exercise sub-window feeds.",
     )
     parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument(
+        "--render-batch-size",
+        type=int,
+        default=8,
+        help="frames per render_batch call in the batched mesh check.",
+    )
     parser.add_argument(
         "--audio-encoder", default="wav2vec", type=str,
         help="ARTalk audio encoder architecture name.",
@@ -150,6 +228,47 @@ def main():
     )
     assert streamed_smoothed is not None, "smoother produced no output"
     assert_match(one_shot_smoothed, streamed_smoothed, args.atol, "streaming smoother")
+
+    # Streaming mesh rendering parity (skipped if FLAME unavailable).
+    if not os.path.exists(FLAME_ASSET_PATH):
+        print(
+            f"[streaming mesh rendering] {FLAME_ASSET_PATH} not found; skipping. "
+            "FLAME has separate access and license terms; see the README."
+        )
+        return
+    from artalk.flame_model import FLAMEModel, RenderMesh
+
+    flame_model = FLAMEModel(
+        n_shape=300, n_exp=100, scale=1.0, no_lmks=True
+    ).to(device)
+    mesh_renderer = RenderMesh(
+        image_size=512, faces=flame_model.get_faces(), scale=1.0
+    )
+
+    one_shot_frames = render_mesh_oneshot_reference(
+        one_shot_motion, model.basic_vae, flame_model, mesh_renderer
+    )
+    renderer = StreamingRenderer(
+        mode="mesh",
+        basic_vae=model.basic_vae,
+        flame_model=flame_model,
+        mesh_renderer=mesh_renderer,
+        device=device,
+    )
+    streamed_frames = torch.stack(list(renderer.feed(one_shot_motion)), dim=0)
+    assert_match_render(
+        one_shot_frames, streamed_frames, "streaming mesh rendering"
+    )
+    batched_frames = torch.cat(
+        [
+            renderer.render_batch(one_shot_motion[i : i + args.render_batch_size])
+            for i in range(0, one_shot_motion.shape[0], args.render_batch_size)
+        ],
+        dim=0,
+    )
+    assert_match_render(
+        one_shot_frames, batched_frames, "batched mesh rendering"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #36 and the next step of the roadmap in #30: a streaming counterpart to the rendering stage, so motion frames can be turned into RGB as they arrive instead of being collected into an MP4 at the end.

## What's included

- **`StreamingRenderer`** (`artalk/rendering.py`) — mirrors the mesh / GAGAvatar branches of `ARTAvatarInferEngine.rendering` behind a streaming API: `render_frame()` for single frames, `render_batch()` for several frames per model invocation, and `feed()` to iterate a motion tensor. An optional `output_uint8` mode converts to HWC uint8 on the GPU before the device-to-host copy (4x less PCIe traffic). Audio/video muxing is left to the caller's transport layer. The renderer takes already-loaded modules as constructor arguments, so callers can share an engine's modules without paying init cost twice; the one-shot `rendering()` path is untouched.
- **Parity checks** — `scripts/check_streaming_parity.py` gains mesh-mode checks for the per-frame and batched paths against the one-shot reference (skipped automatically when `assets/FLAME_with_eye.pt` is absent).
- **Design notes** — `docs/realtime.md` gains the renderer's design decisions and the parity criterion.
- **Package-root exports** — `ARTalkStreamer`, `CausalSavgolSmoother` (missed in #36), and `StreamingRenderer` are exported from `artalk`.

## Why mesh parity is image-level, not bit-exact

FLAME's linear-blend-skinning reduces in a different order over batch `T` (one-shot) vs `T` calls over batch `1` (streaming); the resulting ~1e-7 vertex deltas feed the rasterizer's discrete coverage decisions at silhouette edges, so a handful of outline pixels can flip. The checks therefore assert **mean abs diff < 1e-5 and <0.1% of pixels diverging by more than 1e-2**. Details in `docs/realtime.md`.

## Verification

All four parity checks pass on the released wav2vec checkpoint (streaming inference and smoother bit-exact; both mesh paths well inside tolerance — 9–12 divergent pixels out of 267M on a 13-second clip):

```
[streaming inference] max abs diff:  0.000e+00 → OK
[streaming smoother]  max abs diff:  0.000e+00 → OK
[streaming mesh rendering] mean abs diff: 1.7e-08, 9/267386880 pixels > 1e-2 → OK
[batched mesh rendering]   mean abs diff: 2.7e-08, 12/267386880 pixels > 1e-2 → OK
```

The GAGAvatar mode was smoke-tested against the vendored module (valid finite RGB output; not covered by automated parity because of the asset-download cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)